### PR TITLE
Removal of local_connection creation/deletion

### DIFF
--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -441,7 +441,6 @@ class ModbusClientDeviceTCP(object):
         local_connect = False
 
         if self.socket is None:
-            local_connect = True
             self.connect(self.timeout)
 
         try:
@@ -457,9 +456,8 @@ class ModbusClientDeviceTCP(object):
                     read_offset += read_count
                 else:
                     break
-        finally:
-            if local_connect:
-                self.disconnect()
+        except Exception:
+            self.disconnect()
 
         return resp
 


### PR DESCRIPTION
Removed the concept of a local_connection which meant that a connection was created and deleted everytime a read was performed. Now we have only one connection unless we have an error reading