### PR TITLE
Fix connection handling

### DIFF
--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -455,7 +455,7 @@ class ModbusClientDeviceTCP(object):
                     read_offset += read_count
                 else:
                     break
-        except Exception e:
+        except Exception as e:
             self.disconnect()
             raise e
 

--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -381,7 +381,7 @@ class ModbusClientDeviceTCP(object):
                 self.socket.close()
             self.socket = None
         except Exception:
-            pass
+            self.socket = None
 
     def _read(self, addr, count, op=FUNC_READ_HOLDING):
 
@@ -438,7 +438,6 @@ class ModbusClientDeviceTCP(object):
         resp = ''
         read_count = 0
         read_offset = 0
-        local_connect = False
 
         if self.socket is None:
             self.connect(self.timeout)
@@ -456,8 +455,9 @@ class ModbusClientDeviceTCP(object):
                     read_offset += read_count
                 else:
                     break
-        except Exception:
+        except Exception e:
             self.disconnect()
+            raise e
 
         return resp
 
@@ -517,11 +517,9 @@ class ModbusClientDeviceTCP(object):
 
         write_count = 0
         write_offset = 0
-        local_connect = False
         count = len(data)/2
 
         if self.socket is None:
-            local_connect = True
             self.connect(self.timeout)
 
         try:
@@ -533,9 +531,9 @@ class ModbusClientDeviceTCP(object):
                 self._write(addr + write_offset, data[(write_offset * 2):((write_offset + write_count) * 2)])
                 count -= write_count
                 write_offset += write_count
-        finally:
-            if local_connect:
-                self.disconnect()
+        except Exception as e:
+            self.disconnect()
+            raise e
 
 class ModbusClientDeviceMapped(object):
 


### PR DESCRIPTION
* We changed the finally: clause to an except: clause. This means that we are catching exceptions that normally fell through all the way to the switchdin sunspec_driver and therefore this driver never realises that the connection is lost as measurements are cached in the pysunspec library. (need to diff pysunspec repo not our fork to see the original).
* We also removed the local connection concept in the read only and not the write, so this has also been added.